### PR TITLE
Updated XML for CE1.1 patch.

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetaData>
-	<name>Adeptus Mechanicus: Armoury R1.0 Combat Extended Patch</name>
+	<name>Adeptus Mechanicus: Armoury R1.1 Combat Extended Patch</name>
 	<author>Ogliss</author>
 	<supportedVersions>
         <li>1.0</li>
+        <li>1.1</li>
 	</supportedVersions>
-	<description>V1.0
+	<description>V1.1
 	Patches my armoury mod to work with combat extended
 	
 	load order

--- a/Defs/Ammo/Advanced/OG_Auto_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Auto_Ammo.xml
@@ -139,7 +139,7 @@
     <products>
       <Ammo_OGAutocannon>100</Ammo_OGAutocannon>
     </products>
-	<researchPrerequisite>ImperialHeavyWeapons</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Heavy_Imperial</researchPrerequisite>
   </RecipeDef>
 	
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="OGCCRAutocannonBase">

--- a/Defs/Ammo/Advanced/OG_Bolt_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Bolt_Ammo.xml
@@ -116,7 +116,7 @@
     <products>
       <Ammo_OGBoltStd>30</Ammo_OGBoltStd>
     </products>
-	<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
   </RecipeDef>
 	
 <ThingDef Class="CombatExtended.AmmoDef" ParentName="OGBoltBase">
@@ -164,7 +164,7 @@
     <products>
       <Ammo_OGBoltStalker>30</Ammo_OGBoltStalker>
     </products>
-	<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
   </RecipeDef>
 	
 <ThingDef Class="CombatExtended.AmmoDef" ParentName="OGBoltBase">
@@ -212,7 +212,7 @@
     <products>
       <Ammo_OGBoltHeavyStd>30</Ammo_OGBoltHeavyStd>
     </products>
-	<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
   </RecipeDef>
 	
 <ThingDef Class="CombatExtended.AmmoDef" ParentName="OGBoltBase">
@@ -260,7 +260,7 @@
     <products>
       <Ammo_OGBoltDragonfire>30</Ammo_OGBoltDragonfire>
     </products>
-	<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
   </RecipeDef>
 	
 <ThingDef Class="CombatExtended.AmmoDef" ParentName="OGBoltBase">
@@ -308,7 +308,7 @@
     <products>
       <Ammo_OGBoltHellfire>30</Ammo_OGBoltHellfire>
     </products>
-	<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
   </RecipeDef>
 	
 <ThingDef Class="CombatExtended.AmmoDef" ParentName="OGBoltBase">
@@ -356,7 +356,7 @@
     <products>
       <Ammo_OGBoltKraken>30</Ammo_OGBoltKraken>
     </products>
-	<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
   </RecipeDef>
 	
 <ThingDef Class="CombatExtended.AmmoDef" ParentName="OGBoltBase">
@@ -404,7 +404,7 @@
     <products>
       <Ammo_OGBoltVengeance>30</Ammo_OGBoltVengeance>
     </products>
-	<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
   </RecipeDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Advanced/OG_Distort_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Distort_Ammo.xml
@@ -63,7 +63,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageDef>OGEWraith</damageDef>
+      <damageDef>OG_E_Distortion_Damage</damageDef>
       <speed>135</speed>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Advanced/OG_Flamer_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Flamer_Ammo.xml
@@ -77,7 +77,7 @@
 
 <ThingDef Class="CombatExtended.AmmoDef" Name="BaseOGFlamer" ParentName="BaseBullet" Abstract="true">
     <graphicData>
-      <texPath>Things/Projectile/Fire/FireA</texPath>
+      <texPath>Things/Projectile/FlamerFire/FireA</texPath>
       <graphicClass>Graphic_Single</graphicClass>
       <shaderType>TransparentPostLight</shaderType>
     </graphicData>

--- a/Defs/Ammo/Advanced/OG_Gauss_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Gauss_Ammo.xml
@@ -82,7 +82,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
 <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageDef>OGNGauss</damageDef>
+      <damageDef>OG_N_Gauss_Damage</damageDef>
       <speed>105</speed>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Advanced/OG_Grenades_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Grenades_Ammo.xml
@@ -65,13 +65,16 @@
     <ammoClass>OGGrenadeFrag</ammoClass>
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
-        <explosionDamage>20</explosionDamage>
-        <explosionDamageDef>OGIBomb</explosionDamageDef>
-        <explosionRadius>2.0</explosionRadius>
+        <damageAmountBase>20</damageAmountBase>
+        <explosiveDamageType>OGIBomb</explosiveDamageType>
+        <explosiveRadius>2.0</explosiveRadius>
+        <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      </li>
+      <li Class="CombatExtended.CompProperties_Fragments">
         <fragments>
-          <Fragment_GrenadeFrag>105</Fragment_GrenadeFrag>
+          <!--<Fragment_Small>3</Fragment_Small>-->
+          <Fragment_GrenadeFrag>1</Fragment_GrenadeFrag>
         </fragments>
-		<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       </li>
     </comps>
   </ThingDef>
@@ -89,9 +92,9 @@
     <ammoClass>OGGrenadeKrak</ammoClass>
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
-        <explosionDamage>40</explosionDamage>
-        <explosionDamageDef>OGIBomb</explosionDamageDef>
-        <explosionRadius>1.0</explosionRadius>
+        <damageAmountBase>40</damageAmountBase>
+        <explosiveDamageType>OGIBomb</explosiveDamageType>
+        <explosiveRadius>1.0</explosiveRadius>
       </li>
     </comps>
   </ThingDef>
@@ -115,7 +118,7 @@
       <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>Ogryn grenade</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<explosionRadius>1.550</explosionRadius>
+        <explosionRadius>1.550</explosionRadius>
 			<damageDef>OGIBomb</damageDef>
 			<damageAmountBase>20</damageAmountBase>
 			<soundExplode>OGIAC_Explosion</soundExplode>
@@ -123,11 +126,11 @@
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
-			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<fragments>
-          <Fragment_GrenadeFrag>105</Fragment_GrenadeFrag>
-				</fragments>
-			</li>
+      <li Class="CombatExtended.CompProperties_Fragments">
+        <fragments>
+          <Fragment_Small>3</Fragment_Small>
+        </fragments>
+      </li>
 		</comps>
 	</ThingDef>
 
@@ -136,7 +139,7 @@
       <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>Ogryn grenade</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<explosionRadius>1.0</explosionRadius>
+        <explosionRadius>1.0</explosionRadius>
 			<damageDef>OGIBomb</damageDef>
 			<damageAmountBase>40</damageAmountBase>
 			<soundExplode>OGIAC_Explosion</soundExplode>
@@ -188,7 +191,7 @@
     <products>
       <Ammo_OGGrenadeFragL>20</Ammo_OGGrenadeFragL>
     </products>
-	<researchPrerequisite>ImperialSpecialWeapons</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Special_Imperial</researchPrerequisite>
   </RecipeDef>
 	
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -232,7 +235,7 @@
     <products>
       <Ammo_OGGrenadeKrakL>20</Ammo_OGGrenadeKrakL>
     </products>
-	<researchPrerequisite>ImperialSpecialWeapons</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Special_Imperial</researchPrerequisite>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/OG_Ion_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Ion_Ammo.xml
@@ -67,7 +67,7 @@
     <label>Ion Rifle Beam</label>
 <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>45</damageAmountBase>
-	  <explosionRadius>0.75</explosionRadius>
+  <explosionRadius>0.75</explosionRadius>
       <armorPenetrationBase>3.0</armorPenetrationBase>
 	  <soundExplode>OGIPP_Explosion</soundExplode>
     </projectile>
@@ -105,7 +105,7 @@
     <products>
       <Ammo_OGIon>70</Ammo_OGIon>
     </products>
-	<researchPrerequisite>ImperialHeavyWeapons</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Heavy_Imperial</researchPrerequisite>
   </RecipeDef>
 		
 </Defs>

--- a/Defs/Ammo/Advanced/OG_Las_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Las_Ammo.xml
@@ -234,7 +234,7 @@
     <products>
       <Ammo_OGLasCannon>40</Ammo_OGLasCannon>
     </products>
-	<researchPrerequisite>WRImpLasTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Laser_Imperial</researchPrerequisite>
   </RecipeDef>
 	
 <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseOGLasCharge">
@@ -299,7 +299,7 @@
     <products>
       <Ammo_OGLasCannon>40</Ammo_OGLasCannon>
     </products>
-	<researchPrerequisite>WRImpLasTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Laser_Imperial</researchPrerequisite>
   </RecipeDef>
 	
 	<!--
@@ -392,7 +392,7 @@
     <products>
       <Ammo_OGLasStd>180</Ammo_OGLasStd>
     </products>
-	<researchPrerequisite>WRImpLasTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Laser_Imperial</researchPrerequisite>
   </RecipeDef>
 		
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseOGLasCharge">
@@ -445,7 +445,7 @@
     <products>
       <Ammo_OGLasE>180</Ammo_OGLasE>
     </products>
-	<researchPrerequisite>WRImpLasTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Laser_Imperial</researchPrerequisite>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/OG_Melta_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Melta_Ammo.xml
@@ -139,7 +139,7 @@
     <products>
       <Ammo_OGMelta>20</Ammo_OGMelta>
     </products>
-	<researchPrerequisite>ImperialSpecialWeapons</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Special_Imperial</researchPrerequisite>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/OG_Missiles_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Missiles_Ammo.xml
@@ -65,13 +65,15 @@
     <ammoClass>OGMissileFrag</ammoClass>
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
-        <explosionDamage>20</explosionDamage>
-        <explosionDamageDef>OGIBomb</explosionDamageDef>
-        <explosionRadius>2.0</explosionRadius>
-        <fragments>
-          <Fragment_GrenadeFrag>105</Fragment_GrenadeFrag>
-        </fragments>
+        <damageAmountBase>20</damageAmountBase>
+        <explosiveDamageType>OGIBomb</explosiveDamageType>
+        <explosiveRadius>2.0</explosiveRadius>
 		<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      </li>
+      <li Class="CombatExtended.CompProperties_Fragments">
+        <fragments>
+          <Fragment_RocketFrag>1</Fragment_RocketFrag>
+        </fragments>
       </li>
     </comps>
   </ThingDef>
@@ -89,9 +91,9 @@
     <ammoClass>OGMissileKrak</ammoClass>
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
-        <explosionDamage>40</explosionDamage>
-        <explosionDamageDef>OGIBomb</explosionDamageDef>
-        <explosionRadius>1.0</explosionRadius>
+        <damageAmountBase>40</damageAmountBase>
+        <explosiveDamageType>OGIBomb</explosiveDamageType>
+        <explosiveRadius>1.0</explosiveRadius>
       </li>
     </comps>
   </ThingDef>
@@ -123,18 +125,20 @@
 			<damageDef>OGIBomb</damageDef>
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBase>0.16</armorPenetrationBase>
-			<explosionRadius>4.8</explosionRadius>
+      <explosionRadius>4.8</explosionRadius>
 			<soundExplode>OGIAC_Explosion</soundExplode>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<explosionDamage>75</explosionDamage>
-				<explosionDamageDef>Bomb</explosionDamageDef>
-				<explosionRadius>2</explosionRadius>
-				<fragments>
-					<Fragment_GrenadeFrag>250</Fragment_GrenadeFrag>
-				</fragments>
+				<damageAmountBase>75</damageAmountBase>
+				<explosiveDamageType>Bomb</explosiveDamageType>
+				<explosiveRadius>2</explosiveRadius>
 			</li>
+      <li Class="CombatExtended.CompProperties_Fragments">
+        <fragments>
+          <Fragment_RocketFrag>1</Fragment_RocketFrag>
+        </fragments>
+      </li>
 		</comps>
 	</ThingDef>
 
@@ -150,7 +154,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>OGIBomb</damageDef>
 			<damageAmountBase>70</damageAmountBase>
-			<explosionRadius>1.5</explosionRadius>
+      <explosionRadius>1.5</explosionRadius>
 			<armorPenetrationBase>3</armorPenetrationBase>
 			<soundExplode>OGIAC_Explosion</soundExplode>
 		</projectile>
@@ -199,7 +203,7 @@
     <products>
       <Ammo_OGMissileFrag>20</Ammo_OGMissileFrag>
     </products>
-	<researchPrerequisite>ImperialHeavyWeapons</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Heavy_Imperial</researchPrerequisite>
   </RecipeDef>
 	
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -243,7 +247,7 @@
     <products>
       <Ammo_OGMissileKrak>20</Ammo_OGMissileKrak>
     </products>
-	<researchPrerequisite>ImperialHeavyWeapons</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Heavy_Imperial</researchPrerequisite>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/OG_Plasma_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Plasma_Ammo.xml
@@ -146,7 +146,7 @@
     <products>
       <Ammo_OGPlasmaStd>80</Ammo_OGPlasmaStd>
     </products>
-	<researchPrerequisite>WRImpPlasmaTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Plasma_Imperial</researchPrerequisite>
   </RecipeDef>
 	
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="OGPlasmaBase">
@@ -194,7 +194,7 @@
     <products>
       <Ammo_OGPlasmaOrk>80</Ammo_OGPlasmaOrk>
     </products>
-	<researchPrerequisite>WRImpPlasmaTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Plasma_Imperial</researchPrerequisite>
   </RecipeDef>
 	
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="OGPlasmaBase">
@@ -242,7 +242,7 @@
     <products>
       <Ammo_OGPlasmaLarge>20</Ammo_OGPlasmaLarge>
     </products>
-	<researchPrerequisite>WRImpPlasmaTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Plasma_Imperial</researchPrerequisite>
   </RecipeDef>
 	
 	
@@ -291,7 +291,7 @@
     <products>
       <Ammo_OGPlasmaEld>80</Ammo_OGPlasmaEld>
     </products>
-	<researchPrerequisite>WRImpPlasmaTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Plasma_Imperial</researchPrerequisite>
   </RecipeDef>
 	
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="OGPlasmaBase">
@@ -339,7 +339,7 @@
     <products>
       <Ammo_OGPulse>80</Ammo_OGPulse>
     </products>
-	<researchPrerequisite>WRImpPlasmaTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Plasma_Imperial</researchPrerequisite>
   </RecipeDef>
 	
 	<!-- ================== Projectiles ================== -->
@@ -362,7 +362,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>17</damageAmountBase>
       <armorPenetrationBase>1.5</armorPenetrationBase>
-	  <explosionRadius>0.50</explosionRadius>
+      <explosionRadius>0.50</explosionRadius>
 	  <soundExplode>OGIPP_Explosion</soundExplode>
     </projectile>
   </ThingDef>
@@ -377,7 +377,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>90</damageAmountBase>
       <armorPenetrationBase>3.0</armorPenetrationBase>
-	  <explosionRadius>2.55</explosionRadius>
+      <explosionRadius>2.55</explosionRadius>
 	  <soundExplode>OGIPC_Explosion</soundExplode>
     </projectile>
   </ThingDef>
@@ -389,7 +389,7 @@
 			<damageDef>OGEPlas</damageDef>
       <damageAmountBase>17</damageAmountBase>
       <armorPenetrationBase>1.5</armorPenetrationBase>
-	  <explosionRadius>0.50</explosionRadius>
+      <explosionRadius>0.50</explosionRadius>
 	  <soundExplode>OGIPP_Explosion</soundExplode>
     </projectile>
   </ThingDef>
@@ -401,7 +401,7 @@
 			<damageDef>OGEPlas</damageDef>
       <damageAmountBase>35</damageAmountBase>
       <armorPenetrationBase>1.5</armorPenetrationBase>
-	  <explosionRadius>0.50</explosionRadius>
+      <explosionRadius>0.50</explosionRadius>
 	  <soundExplode>OGIPP_Explosion</soundExplode>
     </projectile>
   </ThingDef>
@@ -413,7 +413,7 @@
 			<damageDef>OGIPlasmaCannon</damageDef>
       <damageAmountBase>100</damageAmountBase>
       <armorPenetrationBase>2.5</armorPenetrationBase>
-	  <explosionRadius>2.55</explosionRadius>
+      <explosionRadius>2.55</explosionRadius>
 	  <soundExplode>OGIPC_Explosion</soundExplode>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Advanced/OG_Radium_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Radium_Ammo.xml
@@ -91,7 +91,7 @@
     <products>
       <Ammo_OGRadium>90</Ammo_OGRadium>
     </products>
-	<researchPrerequisite>WRRadiumWeapons</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Radium_Mechanicus</researchPrerequisite>
   </RecipeDef>
 	<!-- ================== Projectiles ================== -->
 

--- a/Defs/Ammo/Advanced/OG_Railgun_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Railgun_Ammo.xml
@@ -81,7 +81,7 @@
     <products>
       <Ammo_OGRailRifle>40</Ammo_OGRailRifle>
     </products>
-	<researchPrerequisite>WRImpLasTech</researchPrerequisite>
+	<researchPrerequisite>OG_Weapons_Laser_Imperial</researchPrerequisite>
   </RecipeDef>
 		
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Advanced/OG_Sonic_Ammo.xml
+++ b/Defs/Ammo/Advanced/OG_Sonic_Ammo.xml
@@ -94,7 +94,7 @@
     <products>
       <Ammo_OGSonic>100</Ammo_OGSonic>
     </products>
-	<!-- <researchPrerequisite>ImperialHeavyWeapons</researchPrerequisite> -->
+	<!-- <researchPrerequisite>OG_Weapons_Heavy_Imperial</researchPrerequisite> -->
   </RecipeDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/ThingDefs/Eldar_Weapons_Ranged.xml
+++ b/Defs/ThingDefs/Eldar_Weapons_Ranged.xml
@@ -2,7 +2,7 @@
 <Defs>
 
  <!-- ====================== Lasbalster ===================== -->
- <ThingDef Class="AdeptusMechanicus.ThingDef_LaserProjectile" ParentName="BaseBullet">
+<!-- <ThingDef Class="AdeptusMechanicus.ThingDef_LaserProjectile" ParentName="BaseBullet">
 	<defName>OGE_Bullet_LasBlaster</defName>
     <label>Las Blast</label>
     <graphicData>
@@ -26,7 +26,25 @@
 			<postFiringDuration>25</postFiringDuration>
 			<StartFireChance>0.1</StartFireChance>	
  </ThingDef>
+-->
 
+<ThingDef ParentName="OG_Bullet_LaserGeneric" Class="AdeptusMechanicus.LaserBeamDef">
+    <defName>OGE_Bullet_LasBlaster</defName>
+    <label>las blast</label>
+
+    <textures>
+      <li>Things/Projectile/LasShotLrg</li>
+    </textures>
+    <seam>0</seam>
+
+    <projectile>
+      <damageDef>OGILas</damageDef>
+      <damageAmountBase>20</damageAmountBase>
+      <armorPenetrationBase>0.32</armorPenetrationBase>
+      <stoppingPower>1.25</stoppingPower>
+    </projectile>
+  </ThingDef>
+  
  <ThingDef ParentName="OGEldarSpecialGun">
     <defName>OGE_Gun_LasBlaster</defName>
     <label>Lasblaster</label>
@@ -76,7 +94,7 @@
 			<range>35</range>
 			<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
 			<burstShotCount>6</burstShotCount>
-			<soundCast>HellgunSound</soundCast>
+			<soundCast>Hellgun_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>

--- a/Defs/ThingDefs/RangedWeapon_OgChaos.xml
+++ b/Defs/ThingDefs/RangedWeapon_OgChaos.xml
@@ -29,7 +29,7 @@
 		<RangedWeapon_Cooldown>2.25</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>175</Steel>
@@ -55,7 +55,7 @@
 			<!-- <forcedMissRadius>0.01</forcedMissRadius> -->
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>3</burstShotCount>
-			<soundCast>BoltSound</soundCast>
+			<soundCast>Bolt_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -107,7 +107,7 @@
 		<RangedWeapon_Cooldown>1.26</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpPlasmaTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Plasma_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>125</Steel>
@@ -133,7 +133,7 @@
 			<warmupTime>0.4</warmupTime>
 			<range>25</range>
 			<forcedMissRadius>0.5</forcedMissRadius>
-			<soundCast>PlasmaPistolSound</soundCast>
+			<soundCast>Plasma_Pistol_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>10</muzzleFlashScale>
 			<targetParams>
@@ -185,7 +185,7 @@
 		<RangedWeapon_Cooldown>1.75</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpPlasmaTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Plasma_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>175</Steel>
@@ -213,7 +213,7 @@
 			<forcedMissRadius>0.5</forcedMissRadius>
 			<ticksBetweenBurstShots>30</ticksBetweenBurstShots>
 			<burstShotCount>1</burstShotCount>
-			<soundCast>PlasmaPistolSound</soundCast>
+			<soundCast>Plasma_Pistol_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>10</muzzleFlashScale>
 			<targetParams>
@@ -271,7 +271,7 @@
 		<RangedWeapon_Cooldown>3.00</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpPlasmaTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Plasma_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>200</Steel>
@@ -303,7 +303,7 @@
 			<warmupTime>4</warmupTime>
 			<range>45</range>
 			<forcedMissRadius>0.5</forcedMissRadius>
-			<soundCast>PlasmaCannonSound</soundCast>
+			<soundCast>Plasma_Cannon_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -365,7 +365,7 @@
 				<range>31</range>
 				<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 				<burstShotCount>8</burstShotCount>
-				<soundCast>HellgunSound</soundCast>
+				<soundCast>Hellgun_Shot</soundCast>
 				<soundCastTail>GunTail_Light</soundCastTail>
 				<muzzleFlashScale>8</muzzleFlashScale>
 			<targetParams>

--- a/Defs/ThingDefs/RangedWeapon_OgImp.xml
+++ b/Defs/ThingDefs/RangedWeapon_OgImp.xml
@@ -6,10 +6,11 @@
     <label>Bolter</label>
     <description>The Bolter, also called a Boltgun, and its variants are some of the most powerful hand-held ballistic anti-personnel weaponry in use by the military forces of the Imperium of Man. It is a powerful assault weapon that fires explosive kinetic rounds colloquially referred to as bolts. The Bolter is a weapon synonymous with the Adeptus Astartes, and rightly so. However, although the Space Marines are its primary users, the Bolter finds itself in use in military organisations throughout the Imperium. The weapon is fearsome, with explosive rounds capable of ripping through or blowing apart a foe. The Chaos Space Marines of the Traitor Legions were issued their Legions' Bolters before the Horus Heresy, and therefore use generally older variants than the patterns available to present-day Loyalist Space Marines.\n\nSpecial Rules:\nRapid Fire\nRapid Fire Weapons fire twice as many rounds per burst.</description>
     <graphicData>
-		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/BoltGunIII</texPath>
+		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/Bolter</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
 			<shaderType>CutoutComplex</shaderType>
-		<drawSize>1.1</drawSize>			
+      <color>(0.286,0.286,0.286)</color>
+      <drawSize>1.1</drawSize>			
     </graphicData>
 	<comps>     
 		<li>
@@ -30,7 +31,7 @@
 		<RangedWeapon_Cooldown>2.25</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>175</Steel>
@@ -56,7 +57,7 @@
 			<range>31</range>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>3</burstShotCount>
-			<soundCast>BoltSound</soundCast>
+			<soundCast>Bolt_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -139,7 +140,7 @@
 		<RangedWeapon_Cooldown>2.25</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>175</Steel>
@@ -164,7 +165,7 @@
 			<range>31</range>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>3</burstShotCount>
-			<soundCast>BoltSound</soundCast>
+			<soundCast>Bolt_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -180,7 +181,7 @@
 			<range>31</range>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>3</burstShotCount>
-			<soundCast>BoltSound</soundCast>
+			<soundCast>Bolt_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -196,7 +197,7 @@
 			<range>31</range>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>3</burstShotCount>
-			<soundCast>BoltSound</soundCast>
+			<soundCast>Bolt_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -212,7 +213,7 @@
 			<range>31</range>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>3</burstShotCount>
-			<soundCast>BoltSound</soundCast>
+			<soundCast>Bolt_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -228,7 +229,7 @@
 			<range>38</range>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>3</burstShotCount>
-			<soundCast>BoltSound</soundCast>
+			<soundCast>Bolt_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -249,7 +250,7 @@
 			<range>24</range>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>3</burstShotCount>
-			<soundCast>BoltSound</soundCast>
+			<soundCast>Bolt_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -285,7 +286,7 @@
     <label>Heavy Bolter</label>
     <description>A Heavy Bolter is a powerful Bolt Weapon that is used for anti-infantry and fire support roles, and is also known as the "Backbreaker" or the "Bruiser" because of its great weight and the amount of damage it can deal. Unlike the Boltgun, it is relatively common in Imperial Guard armies and is also often used by the Space Marines. Heavy Bolters have a high rate of fire and are relatively cheap to field. A Heavy Bolter can also be mounted on the cupola pintle-mounts of a wide variety of Imperial armoured vehicles, as well as act as an anti-personnel weapon by Imperial fixed defences, including strongholds and other fortifications.</description>
     <graphicData>
-		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/HeavyBolter</texPath>
+		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/BolterHeavy</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
 		<drawSize>1.250</drawSize>			
     </graphicData>
@@ -308,7 +309,7 @@
 		<RangedWeapon_Cooldown>3.00</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>200</Steel>
@@ -335,7 +336,7 @@
 			<range>38</range>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>6</burstShotCount>
-			<soundCast>BoltSound</soundCast>
+			<soundCast>Bolt_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -377,7 +378,7 @@
 			<RangedWeapon_Cooldown>1.00</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpLasTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Laser_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>75</Steel>
@@ -408,7 +409,7 @@
 			<range>25</range>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>4</burstShotCount>
-			<soundCast>LaspistolSound</soundCast>
+			<soundCast>LaspistolShot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -462,7 +463,7 @@
 			<RangedWeapon_Cooldown>0.50</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpLasTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Laser_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>75</Steel>
@@ -491,7 +492,7 @@
 			<range>31</range>
 			<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
 			<burstShotCount>3</burstShotCount>
-			<soundCast>LaspistolSound</soundCast>
+			<soundCast>LaspistolShot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -544,7 +545,7 @@
 			<RangedWeapon_Cooldown>1.70</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpLasTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Laser_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>105</Steel>
@@ -572,7 +573,7 @@
 			<range>35</range>
 			<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
 			<burstShotCount>6</burstShotCount>
-			<soundCast>HellgunSound</soundCast>
+			<soundCast>Hellgun_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -624,7 +625,7 @@
 		<RangedWeapon_Cooldown>1.26</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpPlasmaTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Plasma_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>125</Steel>
@@ -652,7 +653,7 @@
 			<range>25</range>
 			<forcedMissRadius>0.5</forcedMissRadius>
 			<burstShotCount>1</burstShotCount>
-			<soundCast>PlasmaPistolSound</soundCast>
+			<soundCast>Plasma_Pistol_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>10</muzzleFlashScale>
 			<targetParams>
@@ -704,7 +705,7 @@
 		<RangedWeapon_Cooldown>1.75</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpPlasmaTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Plasma_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>175</Steel>
@@ -733,7 +734,7 @@
 			<forcedMissRadius>0.5</forcedMissRadius>
 			<ticksBetweenBurstShots>30</ticksBetweenBurstShots>
 			<burstShotCount>1</burstShotCount>
-			<soundCast>PlasmaPistolSound</soundCast>
+			<soundCast>Plasma_Pistol_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>10</muzzleFlashScale>
 			<targetParams>
@@ -793,7 +794,7 @@
 		<RangedWeapon_Cooldown>3.00</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpPlasmaTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Plasma_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>200</Steel>
@@ -821,7 +822,7 @@
 			<warmupTime>4</warmupTime>
 			<range>45</range>
 			<forcedMissRadius>0.5</forcedMissRadius>
-			<soundCast>PlasmaCannonSound</soundCast>
+			<soundCast>Plasma_Cannon_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -1156,7 +1157,7 @@
       <RangedWeapon_Cooldown>1.35</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>ImperialSpecialWeapons</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Special_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>100</Steel>
@@ -1232,7 +1233,7 @@
 			<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
 		</statBases>
 		<recipeMaker>
-			<researchPrerequisite>ImperialHeavyWeapons</researchPrerequisite>
+			<researchPrerequisite>OG_Weapons_Heavy_Imperial</researchPrerequisite>
 		</recipeMaker>
 		<costList>
 		<Steel>100</Steel>
@@ -1372,7 +1373,7 @@
     <label>Heavy Flamer</label>
     <description>Flamers, also known as "Flame Guns", are Flamer Weapons that come in a wide variety of designs and patterns, but all are ideal for flushing out enemies in cover and putting groups of foes to the torch with projected flame. The two most common variants of Flamers either have a detachable fuel canister under the barrel, or a hose connecting to a backpack canister. Flamers are most commonly used by Imperial assault forces such as Space Marine Assault Squads, though xenos races such as the Eldar, Orks and the Tau are also known to make use of similar weapons.</description>
     <graphicData>
-		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/HeavyFlamer</texPath>
+		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/FlamerHeavy</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <soundInteract>Interact_Rifle</soundInteract>
@@ -1490,7 +1491,7 @@
 			<defaultProjectile>OGI_Bullet_Melta</defaultProjectile>
 			<warmupTime>0.25</warmupTime>
 			<range>16</range>
-			<soundCast>MeltaSound</soundCast>
+			<soundCast>Meltagun_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -1525,7 +1526,7 @@
     <label>MultiMelta</label>
     <description>The Meltagun, also called a "Fusion Gun," "Melter," or "Cooker," is a powerful, short-ranged anti-armour weapon that produces an intense, energetic beam of heat in the tens of thousands of degrees Centigrade. The Melta Gun is used by the Space Marines, the troops of the Imperial Guard and other military forces of the Imperium of Man such as the Orders Militant of the Adepta Sororitas. Melta Weapons emit devastatingly intense but short-ranged blasts of heat which can melt through almost any material. Most types of Melta Weapon like the Meltagun function by inducing highly pressurised gases from an ammunition canister into an unstable sub-molecular state which produces nuclear fusion and directing the resulting energies down the barrel. Melta Weapon usage is always accompanied by a distinctive hissing sound as the Melta beam boils away the water in the air, then a roaring blast as the beam reduces the target to charred scraps or molten slag. Meltaguns are the premier Imperial anti-armour weapons, and few if any vehicles can withstand their power.</description>
     <graphicData>
-		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/MultiMelta</texPath>
+		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/MeltaMulti</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <soundInteract>Interact_Autopistol</soundInteract>
@@ -1564,7 +1565,7 @@
 			<defaultProjectile>OGI_Bullet_Melta</defaultProjectile>
 			<warmupTime>1.5</warmupTime>
 			<range>32</range>
-			<soundCast>MeltaSound</soundCast>
+			<soundCast>Meltagun_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -1599,7 +1600,7 @@
     <label>Combi-Flamer</label>
     <description>Combi-weapons are a variety weaponry derived from the integration of multiple different weapon types into a single weapon.\n\nThere are two major types of Combi-weapons. The first combines two identical weapons into one larger weapon, giving the resulting weapon system a higher rate of fire and better accuracy by virtue of simply throwing more shells, heat beams or plasma at the target. The second type of Combi-weapon is an amalgamation of two wholly different weapons into a single casing.\n\nOnly one component of the combined weapon can be fired at a time, and often the secondary weapon has very limited ammunition, enough for only one shot or short burst of fire. Such weapons augment the bearer's tactical flexibility, granting him a limited capacity to deal with threats that the main weapon would find hard or impossible to damage.\n\nA standard Bolter with a Flamer attached to the side, useful for close combat.</description>
     <graphicData>
-		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/CombiFlamer</texPath>
+		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/BolterCombiFlamer</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
 		<drawSize>1.1</drawSize>			
     </graphicData>
@@ -1620,7 +1621,7 @@
 		<RangedWeapon_Cooldown>2.25</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>175</Steel>
@@ -1646,7 +1647,7 @@
 			<range>31</range>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>3</burstShotCount>
-			<soundCast>BoltSound</soundCast>
+			<soundCast>Bolt_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -1681,7 +1682,7 @@
     <label>Combi-Melta</label>
     <description>Combi-weapons are a variety weaponry derived from the integration of multiple different weapon types into a single weapon.\n\nThere are two major types of Combi-weapons. The first combines two identical weapons into one larger weapon, giving the resulting weapon system a higher rate of fire and better accuracy by virtue of simply throwing more shells, heat beams or plasma at the target. The second type of Combi-weapon is an amalgamation of two wholly different weapons into a single casing.\n\nOnly one component of the combined weapon can be fired at a time, and often the secondary weapon has very limited ammunition, enough for only one shot or short burst of fire. Such weapons augment the bearer's tactical flexibility, granting him a limited capacity to deal with threats that the main weapon would find hard or impossible to damage.\n\nA standard Bolter with a Meltagun attached to its side, used as an anti-armour weapon.</description>
     <graphicData>
-		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/CombiMelta</texPath>
+		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/BolterCombiMelta</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
 		<drawSize>1.1</drawSize>			
     </graphicData>
@@ -1702,7 +1703,7 @@
 		<RangedWeapon_Cooldown>2.25</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>175</Steel>
@@ -1729,7 +1730,7 @@
 			<range>31</range>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>3</burstShotCount>
-			<soundCast>BoltSound</soundCast>
+			<soundCast>Bolt_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -1764,7 +1765,7 @@
     <label>Combi-Plasma</label>
     <description>Combi-weapons are a variety weaponry derived from the integration of multiple different weapon types into a single weapon.\n\nThere are two major types of Combi-weapons. The first combines two identical weapons into one larger weapon, giving the resulting weapon system a higher rate of fire and better accuracy by virtue of simply throwing more shells, heat beams or plasma at the target. The second type of Combi-weapon is an amalgamation of two wholly different weapons into a single casing.\n\nOnly one component of the combined weapon can be fired at a time, and often the secondary weapon has very limited ammunition, enough for only one shot or short burst of fire. Such weapons augment the bearer's tactical flexibility, granting him a limited capacity to deal with threats that the main weapon would find hard or impossible to damage.\n\nA Standard Bolter with a Plasma Gun attached that is useful for a variety of tactical necessities.</description>
     <graphicData>
-		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/CombiPlasma</texPath>
+		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/BolterCombiPlasma</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
 		<drawSize>1.1</drawSize>			
     </graphicData>
@@ -1786,7 +1787,7 @@
 		<RangedWeapon_Cooldown>2.25</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRImpBoltTech</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Bolter_Imperial</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>175</Steel>
@@ -1812,7 +1813,7 @@
 			<range>31</range>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 			<burstShotCount>3</burstShotCount>
-			<soundCast>BoltSound</soundCast>
+			<soundCast>Bolt_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>

--- a/Defs/ThingDefs/RangedWeapon_OgMechanicus.xml
+++ b/Defs/ThingDefs/RangedWeapon_OgMechanicus.xml
@@ -29,7 +29,7 @@
 		<RangedWeapon_Cooldown>2.25</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRRadiumWeapons</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Radium_Mechanicus</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>85</Steel>
@@ -184,7 +184,7 @@
 		<RangedWeapon_Cooldown>2.26</RangedWeapon_Cooldown>
 	</statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRMechanicusPlasma</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Plasma_Mechanicus</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>175</Steel>
@@ -213,7 +213,7 @@
 			<forcedMissRadius>0.1</forcedMissRadius>
 			<burstShotCount>3</burstShotCount>
 			<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
-			<soundCast>PlasmaPistolSound</soundCast>
+			<soundCast>Plasma_Pistol_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>10</muzzleFlashScale>
 			<targetParams>
@@ -262,7 +262,7 @@
 		<RangedWeapon_Cooldown>3.00</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRMechanicusPlasma</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Plasma_Mechanicus</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>200</Steel>
@@ -291,7 +291,7 @@
 			<burstShotCount>3</burstShotCount>
 			<range>40</range>
 			<forcedMissRadius>0.5</forcedMissRadius>
-			<soundCast>PlasmaCannonSound</soundCast>
+			<soundCast>Plasma_Cannon_Shot</soundCast>
 			<soundCastTail>GunTail_Heavy</soundCastTail>
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<targetParams>
@@ -334,7 +334,7 @@
 		<RangedWeapon_Cooldown>2.0</RangedWeapon_Cooldown>
     </statBases>
 	<recipeMaker>
-		<researchPrerequisite>WRMechanicusPlasma</researchPrerequisite>
+		<researchPrerequisite>OG_Weapons_Plasma_Mechanicus</researchPrerequisite>
 	</recipeMaker>
     <costList>
 		<Steel>175</Steel>
@@ -391,7 +391,7 @@
     <label>Cognis Flamer</label>
     <description>A Cognis Flamer is an Imperial Flamer Weapon used by the military forces of the Adeptus Mechanicus which has been outfitted with a Cogitator. The spark-like anger of the Cognis Flamer's artificially intelligent Machine Spirit has been fanned to a roaring blaze. When under duress it will fight with incendiary wrath, even should its wielder be distracted.</description>
     <graphicData>
-		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/CognisFlamer</texPath>
+		<texPath>Things/Item/Equipment/WeaponRanged/Imperial/FlamerCognis</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <soundInteract>Interact_Rifle</soundInteract>

--- a/Defs/ThingDefs/RangedWeapon_OgNecron.xml
+++ b/Defs/ThingDefs/RangedWeapon_OgNecron.xml
@@ -134,7 +134,7 @@
 	</ThingDef>
 
 	<!--==================== Necron - Gauss Cannon =========================-->
-	<ThingDef ParentName="OGNecronGun">
+	<!--<ThingDef ParentName="OGNecronGun">
 		<defName>OGN_Gun_NGaussCannon</defName>
 		<label>Necron Gauss Cannon</label>
 		<description>A Gauss Cannon is type of horrifying Necron Gauss Weapon that can strip a target down molecule by molecule, reducing it to its constituent atoms in a matter of seconds. Gauss Cannons are larger than the more common Gauss Flayers and Gauss Blasters, and feature four barrels which lead to transparent tubes containing the unholy and unknown viridian energy the weapon fires, and an axe-like bayonet underneath the muzzle.\n\nUnlike more conventional directed energy weapons, a Gauss Cannon does not deliver a cutting beam or pure bolt of electromagnetic force or subatomic particles. Instead it emits an emerald, lightning-like molecular disassembling beam capable of reducing flesh, armour and bone to almost nothing. In the case of more powerful Gauss Weapons, this process occurs so rapidly and completely that the emerald beam of energy may appear to punch through its target, though it may be more accurate to think of it as "digging" its way through armour. It is said to be extremely painful to be shot with a Gauss Cannon, and victims die as much from the systemic shock of the assault as the damage caused by the beams.</description>
@@ -163,7 +163,7 @@
 				<defaultProjectile>OGN_Bullet_NGaussCannon</defaultProjectile>
 				<warmupTime>1.5</warmupTime>
 				<range>45</range>
-				<soundCast>GaussCannonSound</soundCast>
+				<soundCast>GaussCannonShot</soundCast>
 				<soundCastTail>GunTail_Light</soundCastTail>
 				<muzzleFlashScale>8</muzzleFlashScale>
 			<targetParams>
@@ -180,10 +180,10 @@
 		<tradeTags>
 			<li>OGNRanged</li>
 		</tradeTags>
-		<costList>				<!-- USED TO CONTROL WHAT IS GIVEN WHEN ITEM IS SMELTED TIER 1-->
+		<costList>				
 			<ComponentIndustrial>1</ComponentIndustrial>
 			<Plasteel>2</Plasteel>
 			<Steel>10</Steel>
 		</costList>
-	</ThingDef>
+	</ThingDef>-->
 </Defs>

--- a/Defs/ThingDefs/RangedWeapon_OgOrk.xml
+++ b/Defs/ThingDefs/RangedWeapon_OgOrk.xml
@@ -71,7 +71,7 @@
 		<label>Twin Linked Shoota</label>
 		<description>Ork Mekboyz often customise their Shootas by adding an additional barrel for more firepower. These custom Shootas cost their clients much more teef than the usual Shoota, and are often utilised by both Ork Nobs and Warbosses. Often times these deadly weapons are incorporated into Mega Armour.</description>
 		<graphicData>
-			<texPath>Things/Item/Equipment/WeaponRanged/Ork/TwinLinkedShoota</texPath>
+			<texPath>Things/Item/Equipment/WeaponRanged/Ork/ShootaTwinLinked</texPath>
 			<graphicClass>Graphic_Single</graphicClass>		
     </graphicData>
 		<soundInteract>Interact_Autopistol</soundInteract>
@@ -200,7 +200,7 @@
 	<label>Plasma Deffgun</label>
 	<description>Deffguns are heavy Ork weapons, fine examples of the Mek's craft that are made from all kinds of materials, mainly scavenged heavy weaponry of other races. Deffguns are so large they must be mounted on a special firing rig strapped to to an Ork's broad shoulders. No man could hope to fit into a Deffgun's rig without heavy augmetics or thick slabs of vat-grown muscle. This cumbersome rig is needed to absorb bone-breaking recoil each time the Deffgun is fired.</description>
 	<graphicData>
-		<texPath>Things/Item/Equipment/WeaponRanged/Ork/PlasmaDeffgun</texPath>
+		<texPath>Things/Item/Equipment/WeaponRanged/Ork/DeffgunPlasma</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
 		<drawSize>1.250</drawSize>			
     </graphicData>

--- a/Defs/ThingDefs/RangedWeapon_OgTau.xml
+++ b/Defs/ThingDefs/RangedWeapon_OgTau.xml
@@ -31,7 +31,7 @@
 				<defaultProjectile>OGT_Bullet_TPulseBlast</defaultProjectile>
 				<warmupTime>0.6</warmupTime>
 				<range>18</range>
-				<soundCast>PlasmaCannonSound</soundCast>
+				<soundCast>Plasma_Cannon_Shot</soundCast>
 				<soundCastTail>GunTail_Light</soundCastTail>
 				<muzzleFlashScale>8</muzzleFlashScale>
 			<targetParams>
@@ -119,7 +119,7 @@
 				<range>36</range>
 				<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 				<burstShotCount>4</burstShotCount>
-				<soundCast>PlasmaPistolSound</soundCast>
+				<soundCast>Plasma_Pistol_Shot</soundCast>
 				<soundCastTail>GunTail_Light</soundCastTail>
 				<muzzleFlashScale>8</muzzleFlashScale>
 			<targetParams>
@@ -204,7 +204,7 @@
 				<defaultProjectile>OGT_Bullet_TIonRifle</defaultProjectile>
 				<warmupTime>2.5</warmupTime>
 				<range>45</range>
-				<soundCast>IonSound</soundCast>
+				<soundCast>Ion_Shot</soundCast>
 				<soundCastTail>GunTail_Medium</soundCastTail>
 				<muzzleFlashScale>10</muzzleFlashScale>
 			<targetParams>

--- a/Patches/ThingDefs_Misc/Melee.Weapons_OgChaos.xml
+++ b/Patches/ThingDefs_Misc/Melee.Weapons_OgChaos.xml
@@ -111,7 +111,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>14</power>
 					<cooldownTime>1.3</cooldownTime>
@@ -120,7 +120,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>1.8</cooldownTime>

--- a/Patches/ThingDefs_Misc/Melee.Weapons_OgDarkEldar.xml
+++ b/Patches/ThingDefs_Misc/Melee.Weapons_OgDarkEldar.xml
@@ -86,7 +86,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>1.8</cooldownTime>
@@ -95,7 +95,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>30</power>
 					<cooldownTime>2.2</cooldownTime>
@@ -190,7 +190,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>ForceCut</li>
+						<li>OG_ForceWeapon_Cut</li>
 					</capacities>
 					<power>15</power>
 					<cooldownTime>1.4</cooldownTime>
@@ -199,7 +199,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>ForceStab</li>
+						<li>OG_ForceWeapon_Stab</li>
 					</capacities>
 					<power>25</power>
 					<cooldownTime>2.0</cooldownTime>
@@ -234,8 +234,8 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Cut</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>27</power>
 					<cooldownTime>1.9</cooldownTime>
@@ -329,7 +329,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>ForceCut</li>
+						<li>OG_ForceWeapon_Cut</li>
 					</capacities>
 					<power>15</power>
 					<cooldownTime>1.4</cooldownTime>
@@ -338,7 +338,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>ForceStab</li>
+						<li>OG_ForceWeapon_Stab</li>
 					</capacities>
 					<power>25</power>
 					<cooldownTime>2.0</cooldownTime>

--- a/Patches/ThingDefs_Misc/Melee.Weapons_OgEldar.xml
+++ b/Patches/ThingDefs_Misc/Melee.Weapons_OgEldar.xml
@@ -167,9 +167,9 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<label>point</label>
+					<label>fist</label>
 					<capacities>
-						<li>PowerBlunt</li>
+						<li>OG_PowerWeapon_Blunt</li>
 					</capacities>
 					<power>66</power>
 					<armorPenetration>1</armorPenetration>
@@ -236,7 +236,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>1.4</cooldownTime>
@@ -245,7 +245,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>30</power>
 					<cooldownTime>2.5</cooldownTime>
@@ -312,7 +312,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>0.7</cooldownTime>
@@ -321,7 +321,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>30</power>
 					<cooldownTime>1.25</cooldownTime>
@@ -388,7 +388,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>1.4</cooldownTime>
@@ -397,7 +397,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>30</power>
 					<cooldownTime>2.5</cooldownTime>
@@ -464,7 +464,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>ForceCut</li>
+						<li>OG_ForceWeapon_Cut</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>1.4</cooldownTime>
@@ -473,7 +473,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>ForceStab</li>
+						<li>OG_ForceWeapon_Stab</li>
 					</capacities>
 					<power>30</power>
 					<cooldownTime>2.5</cooldownTime>
@@ -539,7 +539,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>1.4</cooldownTime>
@@ -548,7 +548,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>30</power>
 					<cooldownTime>2.5</cooldownTime>
@@ -614,7 +614,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
 					<capacities>
-						<li>ForceBlunt</li>
+						<li>OG_ForceWeapon_Blunt</li>
 					</capacities>
 					<power>10</power>
 					<cooldownTime>1.6</cooldownTime>
@@ -664,7 +664,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>1.4</cooldownTime>
@@ -673,7 +673,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>30</power>
 					<cooldownTime>2.5</cooldownTime>
@@ -716,7 +716,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>0.7</cooldownTime>
@@ -725,7 +725,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>30</power>
 					<cooldownTime>1.25</cooldownTime>
@@ -761,8 +761,8 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
 					<capacities>
-						<li>PowerCut</li>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Cut</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>27</power>
 					<cooldownTime>1.9</cooldownTime>
@@ -798,7 +798,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>50.5</power>
 					<cooldownTime>2.3</cooldownTime>
@@ -807,7 +807,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>30</power>
 					<cooldownTime>1.7</cooldownTime>

--- a/Patches/ThingDefs_Misc/Melee.Weapons_OgImp.xml
+++ b/Patches/ThingDefs_Misc/Melee.Weapons_OgImp.xml
@@ -111,7 +111,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>14</power>
 					<cooldownTime>1.3</cooldownTime>
@@ -120,7 +120,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>1.8</cooldownTime>
@@ -145,7 +145,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>25</power>
 					<cooldownTime>1.8</cooldownTime>
@@ -179,7 +179,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>14</power>
 					<cooldownTime>1.3</cooldownTime>
@@ -188,7 +188,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>1.8</cooldownTime>
@@ -222,7 +222,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>14</power>
 					<cooldownTime>0.65</cooldownTime>
@@ -231,7 +231,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>0.9</cooldownTime>
@@ -265,7 +265,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>fist</label>
 					<capacities>
-						<li>PowerBlunt</li>
+						<li>OG_PowerWeapon_Blunt</li>
 					</capacities>
 					<power>66</power>
 					<cooldownTime>2.8</cooldownTime>
@@ -342,7 +342,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>force strike</label>
 					<capacities>
-						<li>ForceBlunt</li>
+						<li>OG_ForceWeapon_Blunt</li>
 					</capacities>
 					<power>18</power>
 					<cooldownTime>1.8</cooldownTime>

--- a/Patches/ThingDefs_Misc/Melee.Weapons_OgMechanicus.xml
+++ b/Patches/ThingDefs_Misc/Melee.Weapons_OgMechanicus.xml
@@ -25,7 +25,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>7</power>
 					<cooldownTime>1.0</cooldownTime>
@@ -34,7 +34,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>10</power>
 					<cooldownTime>1.8</cooldownTime>
@@ -68,7 +68,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>14</power>
 					<cooldownTime>1.0</cooldownTime>
@@ -77,7 +77,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>1.8</cooldownTime>
@@ -172,7 +172,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blades</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>14</power>
 					<armorPenetration>2</armorPenetration>
@@ -181,7 +181,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>30</power>
 					<armorPenetration>3</armorPenetration>

--- a/Patches/ThingDefs_Misc/Melee.Weapons_OgNecron.xml
+++ b/Patches/ThingDefs_Misc/Melee.Weapons_OgNecron.xml
@@ -25,7 +25,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>35</power>
 					<cooldownTime>1.3</cooldownTime>
@@ -68,7 +68,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>1.6</cooldownTime>
@@ -77,7 +77,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>30</power>
 					<cooldownTime>2.1</cooldownTime>
@@ -111,7 +111,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>30</power>
 					<cooldownTime>1.5</cooldownTime>
@@ -120,7 +120,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>50.5</power>
 					<cooldownTime>3</cooldownTime>

--- a/Patches/ThingDefs_Misc/Melee.Weapons_OgOrk.xml
+++ b/Patches/ThingDefs_Misc/Melee.Weapons_OgOrk.xml
@@ -160,7 +160,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>klaws</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>28</power>
 					<cooldownTime>2.4</cooldownTime>

--- a/Patches/ThingDefs_Misc/Melee.Weapons_OgTau.xml
+++ b/Patches/ThingDefs_Misc/Melee.Weapons_OgTau.xml
@@ -61,7 +61,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>blade</label>
 					<capacities>
-						<li>PowerCut</li>
+						<li>OG_PowerWeapon_Cut</li>
 					</capacities>
 					<power>14</power>
 					<cooldownTime>1.3</cooldownTime>
@@ -70,7 +70,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
 					<capacities>
-						<li>PowerStab</li>
+						<li>OG_PowerWeapon_Stab</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>1.8</cooldownTime>
@@ -113,7 +113,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>force strike</label>
 					<capacities>
-					<li>ForceBlunt</li>
+					<li>OG_ForceWeapon_Blunt</li>
 					</capacities>
 					<power>10</power>
 					<cooldownTime>1.8</cooldownTime>

--- a/Patches/ThingDefs_Misc/RangedWeapon_OgChaos.xml
+++ b/Patches/ThingDefs_Misc/RangedWeapon_OgChaos.xml
@@ -26,7 +26,7 @@
       <defaultProjectile>Bullet_OGBoltStd</defaultProjectile>
       <warmupTime>0.5</warmupTime>
       <range>25</range>
-      <soundCast>BoltSound</soundCast>
+      <soundCast>Bolt_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>20</ticksBetweenBurstShots>
@@ -87,7 +87,7 @@
       <defaultProjectile>Bullet_OGBoltStd</defaultProjectile>
       <warmupTime>0.6</warmupTime>
       <range>31</range>
-      <soundCast>BoltSound</soundCast>
+      <soundCast>Bolt_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>20</ticksBetweenBurstShots>
@@ -157,7 +157,7 @@
       <defaultProjectile>Bullet_OGBoltStd</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>31</range>
-      <soundCast>BoltSound</soundCast>
+      <soundCast>Bolt_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -226,7 +226,7 @@
       <defaultProjectile>Bullet_OGBoltHeavyStd</defaultProjectile>
       <warmupTime>3</warmupTime>
       <range>38</range>
-      <soundCast>BoltSound</soundCast>
+      <soundCast>Bolt_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -285,7 +285,7 @@
       <defaultProjectile>Bullet_OGLasCannon</defaultProjectile>
       <warmupTime>4</warmupTime>
       <range>48</range>
-      <soundCast>LascannonSound</soundCast>
+      <soundCast>Lascannon_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
         <targetParams>
@@ -356,7 +356,7 @@
       <defaultProjectile>Bullet_OGPlasmaStd</defaultProjectile>
       <warmupTime>0.4</warmupTime>
       <range>25</range>
-      <soundCast>PlasmaPistolSound</soundCast>
+      <soundCast>Plasma_Pistol_Shot</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>60</ticksBetweenBurstShots>
@@ -431,7 +431,7 @@
       <defaultProjectile>Bullet_OGPlasmaStd</defaultProjectile>
       <warmupTime>0.4</warmupTime>
       <range>25</range>
-      <soundCast>PlasmaPistolSound</soundCast>
+      <soundCast>Plasma_Pistol_Shot</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>60</ticksBetweenBurstShots>
@@ -506,7 +506,7 @@
       <defaultProjectile>Bullet_OGPlasmaCannon</defaultProjectile>
       <warmupTime>4</warmupTime>
       <range>48</range>
-      <soundCast>PlasmaCannonSound</soundCast>
+      <soundCast>Plasma_Cannon_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
         <targetParams>
@@ -562,7 +562,7 @@
       <defaultProjectile>Bullet_OGMelta</defaultProjectile>
       <warmupTime>2</warmupTime>
       <range>16</range>
-      <soundCast>MeltaSound</soundCast>
+      <soundCast>Meltagun_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
         <targetParams>
@@ -628,7 +628,7 @@
       <defaultProjectile>Bullet_OGRAutocannon</defaultProjectile>
       <warmupTime>1.5</warmupTime>
       <range>36</range>
-      <soundCast>AutocannonSound</soundCast>
+      <soundCast>Autocannon_Shot</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>15</ticksBetweenBurstShots>
@@ -696,7 +696,7 @@
       <defaultProjectile>Bullet_OGSonicHeavy</defaultProjectile>
       <warmupTime>1.3</warmupTime>
       <range>48</range>
-      <soundCast>LaspistolSound</soundCast>
+      <soundCast>LaspistolShot</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>8</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -764,7 +764,7 @@
       <defaultProjectile>Bullet_OGSonic</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>31</range>
-      <soundCast>LaspistolSound</soundCast>
+      <soundCast>LaspistolShot</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>8</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>

--- a/Patches/ThingDefs_Misc/RangedWeapon_OgDarkEldar.xml
+++ b/Patches/ThingDefs_Misc/RangedWeapon_OgDarkEldar.xml
@@ -614,7 +614,7 @@
       <defaultProjectile>Bullet_OGMelta</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>16</range>
-      <soundCast>MeltaSound</soundCast>
+      <soundCast>Meltagun_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -673,7 +673,7 @@
       <defaultProjectile>Bullet_OGMelta</defaultProjectile>
       <warmupTime>1.75</warmupTime>
       <range>28</range>
-      <soundCast>MeltaSound</soundCast>
+      <soundCast>Meltagun_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
         <targetParams>

--- a/Patches/ThingDefs_Misc/RangedWeapon_OgEldar.xml
+++ b/Patches/ThingDefs_Misc/RangedWeapon_OgEldar.xml
@@ -26,7 +26,7 @@
       <defaultProjectile>Bullet_OGShuriken</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>25</range>
-      <soundCast>ShurikenSound</soundCast>
+      <soundCast>Shuriken_Shot</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>8</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -94,7 +94,7 @@
       <defaultProjectile>Bullet_OGShuriken</defaultProjectile>
       <warmupTime>1.3</warmupTime>
       <range>28</range>
-      <soundCast>ShurikenSound</soundCast>
+      <soundCast>Shuriken_Shot</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>8</muzzleFlashScale>
 	  <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
@@ -162,7 +162,7 @@
       <defaultProjectile>Bullet_OGShuriken</defaultProjectile>
       <warmupTime>1.3</warmupTime>
       <range>31</range>
-      <soundCast>ShurikenSound</soundCast>
+      <soundCast>Shuriken_Shot</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>8</muzzleFlashScale>
 	  <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
@@ -230,7 +230,7 @@
       <defaultProjectile>Bullet_OGShurikenHeavy</defaultProjectile>
       <warmupTime>0.7</warmupTime>
       <range>45</range>
-      <soundCast>ShurikenSound</soundCast>
+      <soundCast>Shuriken_Shot</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>8</muzzleFlashScale>
 	  <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
@@ -298,7 +298,7 @@
       <defaultProjectile>Bullet_OGPlasmaEld</defaultProjectile>
       <warmupTime>1.5</warmupTime>
       <range>36</range>
-      <soundCast>StarcannonSound</soundCast>
+      <soundCast>Starcannon_Shot</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>15</ticksBetweenBurstShots>
@@ -544,7 +544,7 @@
       <defaultProjectile>Bullet_OGMelta</defaultProjectile>
       <warmupTime>1.75</warmupTime>
       <range>16</range>
-      <soundCast>MeltaSound</soundCast>
+      <soundCast>Meltagun_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
         <targetParams>
@@ -609,7 +609,7 @@
       <defaultProjectile>Bullet_OGNeuralDisruptor</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>20</range>
-		<soundCast>ShurikenSound</soundCast>
+		<soundCast>Shuriken_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
         <targetParams>
@@ -675,7 +675,7 @@
       <defaultProjectile>Bullet_OGLasE</defaultProjectile>
       <warmupTime>1.75</warmupTime>
       <range>31</range>
-      <soundCast>MeltaSound</soundCast>
+      <soundCast>Meltagun_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
         <burstShotCount>8</burstShotCount>

--- a/Patches/ThingDefs_Misc/RangedWeapon_OgImp.xml
+++ b/Patches/ThingDefs_Misc/RangedWeapon_OgImp.xml
@@ -28,7 +28,7 @@
       <defaultProjectile>Bullet_OGBoltStd</defaultProjectile>
       <warmupTime>0.5</warmupTime>
       <range>25</range>
-      <soundCast>BoltSound</soundCast>
+      <soundCast>Bolt_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>20</ticksBetweenBurstShots>
@@ -86,7 +86,7 @@
 							<range>31</range>
 							<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 							<burstShotCount>3</burstShotCount>
-							<soundCast>BoltSound</soundCast>
+							<soundCast>Bolt_Shot</soundCast>
 							<soundCastTail>GunTail_Heavy</soundCastTail>
 							<muzzleFlashScale>14</muzzleFlashScale>
 							<targetParams>
@@ -118,7 +118,7 @@
 				<range>31</range>
 				<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
 				<burstShotCount>3</burstShotCount>
-				<soundCast>BoltSound</soundCast>
+				<soundCast>Bolt_Shot</soundCast>
 				<soundCastTail>GunTail_Heavy</soundCastTail>
 				<muzzleFlashScale>14</muzzleFlashScale>
 				<targetParams>
@@ -148,7 +148,7 @@
       <defaultProjectile>Bullet_OGBoltStd</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>31</range>
-      <soundCast>BoltSound</soundCast>
+      <soundCast>Bolt_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -217,7 +217,7 @@
       <defaultProjectile>Bullet_OGBoltStd</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>31</range>
-      <soundCast>BoltSound</soundCast>
+      <soundCast>Bolt_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -285,7 +285,7 @@
       <defaultProjectile>Bullet_OGBoltStalker</defaultProjectile>
       <warmupTime>1.7</warmupTime>
       <range>30</range>
-      <soundCast>BoltSound</soundCast>
+      <soundCast>Bolt_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
 	  <ticksBetweenBurstShots>30</ticksBetweenBurstShots>
@@ -353,7 +353,7 @@
       <defaultProjectile>Bullet_OGBoltHeavyStd</defaultProjectile>
       <warmupTime>3</warmupTime>
       <range>36</range>
-      <soundCast>BoltSound</soundCast>
+      <soundCast>Bolt_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -412,7 +412,7 @@
       <defaultProjectile>Bullet_OGLasStd</defaultProjectile>
       <warmupTime>1</warmupTime>
       <range>25</range>
-      <soundCast>LaspistolSound</soundCast>
+      <soundCast>LaspistolShot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -481,7 +481,7 @@
       <defaultProjectile>Bullet_OGLasStd</defaultProjectile>
       <warmupTime>1</warmupTime>
       <range>31</range>
-      <soundCast>LaspistolSound</soundCast>
+      <soundCast>LaspistolShot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -551,7 +551,7 @@
       <defaultProjectile>Bullet_OGLasHot</defaultProjectile>
       <warmupTime>1</warmupTime>
       <range>31</range>
-      <soundCast>HellgunSound</soundCast>
+      <soundCast>Hellgun_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -620,7 +620,7 @@
       <defaultProjectile>Bullet_OGLasLong</defaultProjectile>
       <warmupTime>2</warmupTime>
       <range>45</range>
-      <soundCast>LongLasSound</soundCast>
+      <soundCast>LongLas_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
         <targetParams>
@@ -685,7 +685,7 @@
       <defaultProjectile>Bullet_OGLasCannon</defaultProjectile>
       <warmupTime>4</warmupTime>
       <range>48</range>
-      <soundCast>LascannonSound</soundCast>
+      <soundCast>Lascannon_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
         <targetParams>
@@ -756,7 +756,7 @@
       <defaultProjectile>Bullet_OGPlasmaStd</defaultProjectile>
       <warmupTime>0.4</warmupTime>
       <range>25</range>
-      <soundCast>PlasmaPistolSound</soundCast>
+      <soundCast>Plasma_Pistol_Shot</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>60</ticksBetweenBurstShots>
@@ -830,7 +830,7 @@
       <defaultProjectile>Bullet_OGPlasmaStd</defaultProjectile>
       <warmupTime>0.4</warmupTime>
       <range>31</range>
-      <soundCast>PlasmaPistolSound</soundCast>
+      <soundCast>Plasma_Pistol_Shot</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>30</ticksBetweenBurstShots>
@@ -904,7 +904,7 @@
       <defaultProjectile>Bullet_OGPlasmaCannon</defaultProjectile>
       <warmupTime>4</warmupTime>
       <range>48</range>
-      <soundCast>PlasmaCannonSound</soundCast>
+      <soundCast>Plasma_Cannon_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
         <targetParams>
@@ -1156,7 +1156,7 @@
       <defaultProjectile>Bullet_OGRAutocannon</defaultProjectile>
       <warmupTime>1</warmupTime>
       <range>48</range>
-      <soundCast>AutocannonSound</soundCast>
+      <soundCast>Autocannon_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>60</ticksBetweenBurstShots>
@@ -1626,7 +1626,7 @@
       <defaultProjectile>Bullet_OGMelta</defaultProjectile>
       <warmupTime>2</warmupTime>
       <range>16</range>
-      <soundCast>MeltaSound</soundCast>
+      <soundCast>Meltagun_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
         <targetParams>
@@ -1691,7 +1691,7 @@
       <defaultProjectile>Bullet_OGMultiMelta</defaultProjectile>
       <warmupTime>2</warmupTime>
       <range>24</range>
-      <soundCast>MeltaSound</soundCast>
+      <soundCast>Meltagun_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
         <targetParams>
@@ -1758,7 +1758,7 @@
       <defaultProjectile>Bullet_OGBoltStd</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>31</range>
-      <soundCast>BoltSound</soundCast>
+      <soundCast>Bolt_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -1828,7 +1828,7 @@
       <defaultProjectile>Bullet_OGBoltStd</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>31</range>
-      <soundCast>BoltSound</soundCast>
+      <soundCast>Bolt_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -1898,7 +1898,7 @@
       <defaultProjectile>Bullet_OGBoltStd</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>31</range>
-      <soundCast>BoltSound</soundCast>
+      <soundCast>Bolt_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>

--- a/Patches/ThingDefs_Misc/RangedWeapon_OgMechanicus.xml
+++ b/Patches/ThingDefs_Misc/RangedWeapon_OgMechanicus.xml
@@ -296,7 +296,7 @@
       <defaultProjectile>Bullet_OGPlasmaStd</defaultProjectile>
       <warmupTime>1.5</warmupTime>
       <range>28</range>
-      <soundCast>PlasmaPistolSound</soundCast>
+      <soundCast>Plasma_Pistol_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>30</muzzleFlashScale>
 	  <ticksBetweenBurstShots>15</ticksBetweenBurstShots>
@@ -371,7 +371,7 @@
       <defaultProjectile>Bullet_OGPlasmaCannon</defaultProjectile>
       <warmupTime>4</warmupTime>
       <range>36</range>
-      <soundCast>PlasmaCannonSound</soundCast>
+      <soundCast>Plasma_Cannon_Shot</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
 	  <ticksBetweenBurstShots>30</ticksBetweenBurstShots>

--- a/Patches/ThingDefs_Misc/RangedWeapon_OgNecron.xml
+++ b/Patches/ThingDefs_Misc/RangedWeapon_OgNecron.xml
@@ -134,7 +134,7 @@
       <defaultProjectile>Bullet_OGGaussCannon</defaultProjectile>
       <warmupTime>0.5</warmupTime>
       <range>36</range>
-      <soundCast>GaussCannonSound</soundCast>
+      <soundCast>GaussCannonShot</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>8</muzzleFlashScale>
         <targetParams>

--- a/Patches/ThingDefs_Misc/RangedWeapon_OgTau.xml
+++ b/Patches/ThingDefs_Misc/RangedWeapon_OgTau.xml
@@ -26,7 +26,7 @@
       <defaultProjectile>Bullet_OGPulse</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>25</range>
-      <soundCast>PlasmaPistolSound</soundCast>
+      <soundCast>Plasma_Pistol_Shot</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>8</muzzleFlashScale>
         <targetParams>
@@ -91,7 +91,7 @@
       <defaultProjectile>Bullet_OGPulse</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>28</range>
-      <soundCast>PlasmaPistolSound</soundCast>
+      <soundCast>Plasma_Pistol_Shot</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>8</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -224,7 +224,7 @@
       <defaultProjectile>Bullet_OGPulse</defaultProjectile>
       <warmupTime>1.5</warmupTime>
       <range>18</range>
-      <soundCast>PlasmaPistolSound</soundCast>
+      <soundCast>Plasma_Pistol_Shot</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
 	  <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
@@ -335,7 +335,7 @@
       <defaultProjectile>Bullet_OGKroot</defaultProjectile>
       <warmupTime>1.3</warmupTime>
       <range>31</range>
-      <soundCast>PlasmaPistolSound</soundCast>
+      <soundCast>Plasma_Pistol_Shot</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>8</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -535,7 +535,7 @@
       <defaultProjectile>Bullet_OGPulseBlast</defaultProjectile>
       <warmupTime>0.3</warmupTime>
       <range>18</range>
-      <soundCast>PlasmaPistolSound</soundCast>
+      <soundCast>Plasma_Pistol_Shot</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>8</muzzleFlashScale>
         <targetParams>
@@ -602,7 +602,7 @@
       <defaultProjectile>Bullet_OGPulse</defaultProjectile>
       <warmupTime>1.3</warmupTime>
       <range>30</range>
-      <soundCast>PlasmaPistolSound</soundCast>
+      <soundCast>Plasma_Pistol_Shot</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>8</muzzleFlashScale>
 	  <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
@@ -672,7 +672,7 @@
       <defaultProjectile>Bullet_OGIonRifle</defaultProjectile>
       <warmupTime>1.5</warmupTime>
       <range>48</range>
-      <soundCast>IonSound</soundCast>
+      <soundCast>Ion_Shot</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>10</muzzleFlashScale>
         <targetParams>


### PR DESCRIPTION
Need to Balance Fragmenting Explosives as that has changed completely.

Known Problems:
Missing some sounds (Just warnings).
Need to set Target Framework to .NET 4.7.2 (from 3.5)

Might not work with 1.0 because of how Harmony patch works for re-naming tech and other things. Haven't tried yet